### PR TITLE
Fix issue with build number being appended in the release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ on:
       - '**/*.pdn'
       - '.github/FUNDING.yml'
 
+env:
+  APPEND_BUILD_NUMBER: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,6 @@ on:
   push:
     tags:
       - 'v*' # Run if someone pushes a semantic versioned tag to the GitHub repo
-  workflow_dispatch:
-    inputs:
-      test-run:
-        description: 'Test (y/n)?'
-        required: true
-        default: 'y'
 
 env:
   APPEND_BUILD_NUMBER: false
@@ -83,31 +77,13 @@ jobs:
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2
         with:
-          validation_level: warn
+          validation_level: error
           version: ${{ steps.version.outputs.release }}
           path: ./CHANGELOG.md
 
       - uses: Kir-Antipov/mc-publish@v3.2
         if: ${{ github.event.inputs.test-run != 'y' }}
         with:
-          #modrinth-id: Read from fabric.mod.json custom.modmanager.modrinth
-          modrinth-featured: true
-          modrinth-unfeature-mode: subset
-          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
-
-          #curseforge-id: Read from fabric.mod.json custom.modmanager.curseforge
-          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
-
-          github-generate-changelog: false
-          github-changelog: ${{ steps.changelog_reader.outputs.changes }}
-          github-draft: false
-          github-prerelease: false
-          github-discussion: Announcements
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-          files-primary: build/libs/!(*-@(dev|sources|javadoc)).jar
-          files-secondary: build/libs/*-@(dev|sources|javadoc).jar
-
           name: v${{ steps.version.outputs.release }} for ${{ steps.version.outputs.build }}
           version: ${{ steps.version.outputs.release }}+${{ steps.version.outputs.build }}
           version-type: release
@@ -123,6 +99,24 @@ jobs:
             modmenu | suggests | *
           java: |
             17
+
+          files-primary: build/libs/!(*-@(dev|sources|javadoc)).jar
+
+          #modrinth-id: Read from fabric.mod.json custom.modmanager.modrinth
+          modrinth-featured: true
+          modrinth-unfeature-mode: subset
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+
+          #curseforge-id: Read from fabric.mod.json custom.modmanager.curseforge
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+
+          github-generate-changelog: false
+          github-changelog: ${{ steps.changelog_reader.outputs.changes }}
+          github-draft: false
+          github-prerelease: false
+          github-discussion: Announcements
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-files-secondary: build/libs/*-@(dev|sources|javadoc).jar
 
           retry-attempts: 2
           retry-delay: 10000

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         default: 'y'
 
 env:
-  CI_RELEASE: true
+  APPEND_BUILD_NUMBER: false
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1]
+### Fixed
+- Build number should not show up in the jar name anymore
+
 ## [1.3.0]
 ### Added
 - Add the ability to click through signs and item frames
   - Sign click through is prevented when holding a sign, dye, an ink sac, or a glowing ink sac in your main hand
   - Item Frame click through is prevented while sneaking or if the item frame has no item in it
 
-### Changes
+### Changed
 - Update yarn mappings version to 1.19.3+build.5
 - Update fabric loader to 0.14.12
 - Update fabric api to 0.70.0+1.19.3
@@ -22,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add the ability to edit signs ([#34](https://github.com/ChristopherHaws/mc-text-utilities/pull/34))
 
-### Changes
+### Changed
 - Split client and server code make it harder to introduce runtime bugs ([#31](https://github.com/ChristopherHaws/mc-text-utilities/pull/31))
 - Update fabric loader to 0.14.11 ([#36](https://github.com/ChristopherHaws/mc-text-utilities/pull/36))
 - Update fabric api to 0.68.0+1.19.2 ([#36](https://github.com/ChristopherHaws/mc-text-utilities/pull/36))

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,7 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 String buildNumber = System.getenv("GITHUB_RUN_NUMBER")
-Boolean isRelease = System.getenv("CI_RELEASE") == "true"
-Boolean appendBuildNumber = isRelease && buildNumber != null
+Boolean appendBuildNumber = System.getenv("APPEND_BUILD_NUMBER") == "true" && buildNumber != null
 
 version = project.mod_version +
         (appendBuildNumber ? "-build${buildNumber}" : "") +
@@ -32,11 +31,11 @@ loom {
 
 	runs {
 		client {
-			runDir = "run/client"
+			runDir = "run/1.19.3/client"
             vmArg "-XX:+ShowCodeDetailsInExceptionMessages"
 		}
 		server {
-			runDir = "run/server"
+			runDir = "run/1.19.3/server"
             vmArg "-XX:+ShowCodeDetailsInExceptionMessages"
 		}
 	}


### PR DESCRIPTION
- Build number is no longer applied to the output jar in release builds
- Added Minecraft version to run directory path to make it easier to switch branches
- Switch release to only release the source jar to GitHub
- Fix changelog