### PR TITLE
Minecraft 1.20.2, 1.20.3 and 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
 	// https://fabricmc.net/wiki/documentation:fabric_loom
-	id 'fabric-loom' version '1.3-SNAPSHOT'
+	id 'fabric-loom' version '1.4-SNAPSHOT'
     // https://plugins.gradle.org/plugin/io.github.juuxel.loom-vineflower
-    id 'io.github.juuxel.loom-vineflower' version '1.11.0'
+    //id 'io.github.juuxel.loom-vineflower' version '1.11.0'
 	id 'maven-publish'
 	id 'idea'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,16 +9,16 @@ org.gradle.jvmargs = -Xmx6G
 org.gradle.parallel = true
 
 # Fabric Properties: https://fabricmc.net/develop
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
+minecraft_version=1.20.3
+yarn_mappings=1.20.3+build.1
 loader_version=0.15.1
 
 #Fabric api
-fabric_version=0.91.2+1.20.2
+fabric_version=0.91.1+1.20.3
 
 # Shedaniel API's: https://linkie.shedaniel.me/dependencies
-modmenu_version = 8.0.0-beta.2
-cloth_config_version = 12.0.113
+modmenu_version = 9.0.0-pre.1
+cloth_config_version = 13.0.114
 
 # Local dev mod versions
 rei_version = 13.0.679

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,16 +9,16 @@ org.gradle.jvmargs = -Xmx6G
 org.gradle.parallel = true
 
 # Fabric Properties: https://fabricmc.net/develop
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.14.21
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.4
+loader_version=0.15.1
 
 #Fabric api
-fabric_version=0.86.0+1.20.1
+fabric_version=0.91.2+1.20.2
 
 # Shedaniel API's: https://linkie.shedaniel.me/dependencies
-modmenu_version = 7.1.0
-cloth_config_version = 11.0.99
+modmenu_version = 8.0.0-beta.2
+cloth_config_version = 12.0.113
 
 # Local dev mod versions
-rei_version = 12.0.625
+rei_version = 13.0.679

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,16 +9,16 @@ org.gradle.jvmargs = -Xmx6G
 org.gradle.parallel = true
 
 # Fabric Properties: https://fabricmc.net/develop
-minecraft_version=1.20.3
-yarn_mappings=1.20.3+build.1
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.1
 loader_version=0.15.1
 
 #Fabric api
-fabric_version=0.91.1+1.20.3
+fabric_version=0.91.2+1.20.4
 
 # Shedaniel API's: https://linkie.shedaniel.me/dependencies
 modmenu_version = 9.0.0-pre.1
 cloth_config_version = 13.0.114
 
 # Local dev mod versions
-rei_version = 13.0.679
+rei_version = 14.0.680

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/io/chaws/textutilities/client/handlers/FormatButtonsHandler.java
+++ b/src/client/java/io/chaws/textutilities/client/handlers/FormatButtonsHandler.java
@@ -1,21 +1,25 @@
 package io.chaws.textutilities.client.handlers;
 
-import com.google.common.collect.ImmutableList;
-import io.chaws.textutilities.TextUtilities;
 import java.util.ArrayList;
 import java.util.List;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
-import net.fabricmc.fabric.api.client.screen.v1.Screens;
+
+import com.google.common.collect.ImmutableList;
+import io.chaws.textutilities.TextUtilities;
+
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.AnvilScreen;
 import net.minecraft.client.gui.screen.ingame.BookEditScreen;
+import net.minecraft.client.gui.screen.ingame.HangingSignEditScreen;
 import net.minecraft.client.gui.screen.ingame.SignEditScreen;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+import net.fabricmc.fabric.api.client.screen.v1.Screens;
 
 @Environment(EnvType.CLIENT)
 public class FormatButtonsHandler {
@@ -61,7 +65,8 @@ public class FormatButtonsHandler {
 		var xOffsetFromCenter = 0;
 		var yOffset = 0;
 
-		if (screen instanceof SignEditScreen) {
+		if (screen instanceof SignEditScreen ||
+			screen instanceof HangingSignEditScreen) {
 			if (!config.signFormattingEnabled) {
 				return;
 			}

--- a/src/client/java/io/chaws/textutilities/client/mixin/AnvilScreenMixin.java
+++ b/src/client/java/io/chaws/textutilities/client/mixin/AnvilScreenMixin.java
@@ -92,7 +92,7 @@ public abstract class AnvilScreenMixin
 		}
 
 		var json = nameElement.asString();
-		var text = Text.Serializer.fromJson(json);
+		var text = Text.Serialization.fromJson(json);
 		if (text == null) {
 			return;
 		}

--- a/src/client/java/io/chaws/textutilities/client/mixin/TextFieldWidgetMixin.java
+++ b/src/client/java/io/chaws/textutilities/client/mixin/TextFieldWidgetMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Environment(EnvType.CLIENT)
 @Mixin(TextFieldWidget.class)
 public class TextFieldWidgetMixin {
-	@Redirect(method = "renderButton", at = @At(value = "INVOKE", target = "Ljava/lang/String;substring(I)Ljava/lang/String;", ordinal = 1))
+	@Redirect(method = "renderWidget", at = @At(value = "INVOKE", target = "Ljava/lang/String;substring(I)Ljava/lang/String;", ordinal = 1))
 	private String appendFormatting(String string, int i) {
 		var strings = FormattingUtils.splitWithFormatting(string, i);
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,7 +39,7 @@
 	"depends": {
 		"fabricloader": ">=0.15",
 		"fabric": "*",
-		"minecraft": ">=1.20.2",
+		"minecraft": ">=1.20.3",
 		"java": ">=17"
 	},
 	"suggests": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,7 +39,7 @@
 	"depends": {
 		"fabricloader": ">=0.15",
 		"fabric": "*",
-		"minecraft": ">=1.20.3",
+		"minecraft": ">=1.20.4",
 		"java": ">=17"
 	},
 	"suggests": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,13 +37,13 @@
 		"cloth-config": "*"
 	},
 	"depends": {
-		"fabricloader": ">=0.14",
+		"fabricloader": ">=0.15",
 		"fabric": "*",
-		"minecraft": ">=1.20",
+		"minecraft": ">=1.20.2",
 		"java": ">=17"
 	},
 	"suggests": {
-		"modmenu": ">=5"
+		"modmenu": ">=8"
 	},
 	"conflicts": {
 		"clickthrough": "*",


### PR DESCRIPTION
Bump up version to Minecraft 1.20.2, 1.20.3 and 1.20.4

## 📑 Description

I changed dependencies as recommended on https://linkie.shedaniel.dev/dependencies , recompiled the sources and changed a few lines to be compatible with the changes in Minecraft code.

## ℹ Additional Information

Please test all three versions before publishing, or publish them as beta.  
I tested the main functions and they seem to be working, but I have not tested everything.